### PR TITLE
Added CAN Debugger device VID and PID.

### DIFF
--- a/drivers/net/can/usb/gs_usb.c
+++ b/drivers/net/can/usb/gs_usb.c
@@ -30,6 +30,9 @@
 #define USB_CES_CANEXT_FD_VENDOR_ID    0x1cd2
 #define USB_CES_CANEXT_FD_PRODUCT_ID   0x606f
 
+#define USB_CAN_DEBUGGER_VENDOR_ID    0x16d0
+#define USB_CAN_DEBUGGER_PRODUCT_ID   0x10b8
+
 #define GSUSB_ENDPOINT_IN          1
 #define GSUSB_ENDPOINT_OUT         2
 
@@ -1175,6 +1178,8 @@ static const struct usb_device_id gs_usb_table[] = {
 				      USB_CANDLELIGHT_PRODUCT_ID, 0) },
 	{ USB_DEVICE_INTERFACE_NUMBER(USB_CES_CANEXT_FD_VENDOR_ID,
 				      USB_CES_CANEXT_FD_PRODUCT_ID, 0) },
+	{ USB_DEVICE_INTERFACE_NUMBER(USB_CAN_DEBUGGER_VENDOR_ID,
+				      USB_CAN_DEBUGGER_PRODUCT_ID, 0) },
 	{} /* Terminating entry */
 };
 


### PR DESCRIPTION
PR to add my devices VID/PID. I'll submit another PR over the weekend with some work on FD feature detection - I aim to remove the current VID checks that gate FD functionality and instead rely on the device stating it's FD capability. I've made a start on this but happy to discuss here and change if you have something else in mind.